### PR TITLE
Fix build failure

### DIFF
--- a/tab_events.md
+++ b/tab_events.md
@@ -1,5 +1,5 @@
 ---
-title: PreviousMeetings
+title: events
 displaytext: Previous Meetings
 layout:  null
 tab: true


### PR DESCRIPTION
tab filename needs to correspond with title front matter element.

Having tabs for "Past Events" and "Previous Meetings" is confusing but I'll let you sort that out.

Ref: https://owasp.org/migration/

@danishka saw your leaders list post about build failures 😉 